### PR TITLE
Factor out the Servitude::NS hack

### DIFF
--- a/examples/1_simple_server
+++ b/examples/1_simple_server
@@ -21,17 +21,6 @@ module SimpleServer
   VERSION    = '1.0.0'
 
   PROJECT_ROOT = File.expand_path( '../..', __FILE__ )
-  
-  boot host_namespace: SimpleServer,
-       app_id: 'simple-server',
-       app_name: 'Simple Server',
-       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
-       author: 'LFE',
-       use_config: false,
-       default_config_path: nil,
-       default_log_path: nil,
-       default_pid_path: nil,
-       default_thread_count: nil
 
   class Server
 
@@ -46,6 +35,17 @@ module SimpleServer
     end
 
   end
+
+  boot host_namespace: SimpleServer,
+       app_id: 'simple-server',
+       app_name: 'Simple Server',
+       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
+       author: 'LFE',
+       use_config: false,
+       default_config_path: nil,
+       default_log_path: nil,
+       default_pid_path: nil,
+       default_thread_count: nil
 end
 
 SimpleServer::Server.new.start

--- a/examples/2_echo_server
+++ b/examples/2_echo_server
@@ -27,17 +27,6 @@ module EchoServer
   VERSION    = '1.0.0'
 
   PROJECT_ROOT = File.expand_path( '../..', __FILE__ )
-  
-  boot host_namespace: EchoServer,
-       app_id: 'echo-server',
-       app_name: 'Echo Server',
-       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
-       author: 'LFE',
-       use_config: false,
-       default_config_path: nil,
-       default_log_path: nil,
-       default_pid_path: nil,
-       default_thread_count: nil
 
   class Server
 
@@ -68,6 +57,17 @@ module EchoServer
     attr_reader :tcp_server
 
   end
+
+  boot host_namespace: EchoServer,
+       app_id: 'echo-server',
+       app_name: 'Echo Server',
+       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
+       author: 'LFE',
+       use_config: false,
+       default_config_path: nil,
+       default_log_path: nil,
+       default_pid_path: nil,
+       default_thread_count: nil
 end
 
 EchoServer::Server.new.start

--- a/examples/3_echo_server_with_cli_and_daemon
+++ b/examples/3_echo_server_with_cli_and_daemon
@@ -38,20 +38,6 @@ module EchoServer
   VERSION    = '1.0.0'
 
   PROJECT_ROOT = File.expand_path( '../..', __FILE__ )
-  
-  boot host_namespace: EchoServer,
-       app_id: 'echo-server-with-cli',
-       app_name: 'Echo Server With CLI',
-       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
-       author: 'LFE',
-       use_config: false,
-       default_config_path: "#{PROJECT_ROOT}}/config/#{APP_FOLDER}.conf",
-       default_log_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.log",
-       default_pid_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.pid",
-       default_thread_count: nil
-
-  class Cli < Servitude::Cli::Service
-  end
 
   class Server
 
@@ -88,6 +74,21 @@ module EchoServer
     attr_reader :tcp_server
 
   end
+
+  boot host_namespace: EchoServer,
+       app_id: 'echo-server-with-cli',
+       app_name: 'Echo Server With CLI',
+       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
+       author: 'LFE',
+       use_config: false,
+       default_config_path: "#{PROJECT_ROOT}}/config/#{APP_FOLDER}.conf",
+       default_log_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.log",
+       default_pid_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.pid",
+       default_thread_count: nil
+
+  class Cli < Servitude::Cli::Service
+  end
+
 end
 
 EchoServer::Cli.start

--- a/examples/4_echo_server_with_cli_daemon_and_file_config
+++ b/examples/4_echo_server_with_cli_daemon_and_file_config
@@ -38,20 +38,6 @@ module EchoServer
   VERSION    = '1.0.0'
 
   PROJECT_ROOT = File.expand_path( '../..', __FILE__ )
-  
-  boot host_namespace: EchoServer,
-       app_id: 'echo-server-with-cli-and-file-config',
-       app_name: 'Echo Server With CLI And File Config',
-       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
-       author: 'LFE',
-       use_config: true,
-       default_config_path: "#{PROJECT_ROOT}/config/4.conf",
-       default_log_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.log",
-       default_pid_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.pid",
-       default_thread_count: nil
-
-  class Cli < Servitude::Cli::Service
-  end
 
   class Server
 
@@ -88,6 +74,21 @@ module EchoServer
     attr_reader :tcp_server
 
   end
+
+  boot host_namespace: EchoServer,
+       app_id: 'echo-server-with-cli-and-file-config',
+       app_name: 'Echo Server With CLI And File Config',
+       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
+       author: 'LFE',
+       use_config: true,
+       default_config_path: "#{PROJECT_ROOT}/config/4.conf",
+       default_log_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.log",
+       default_pid_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.pid",
+       default_thread_count: nil
+
+  class Cli < Servitude::Cli::Service
+  end
+
 end
 
 EchoServer::Cli.start

--- a/examples/5_echo_server_with_cli_daemon_and_env_config
+++ b/examples/5_echo_server_with_cli_daemon_and_env_config
@@ -46,20 +46,6 @@ module EchoServer
   VERSION    = '1.0.0'
 
   PROJECT_ROOT = File.expand_path( '../..', __FILE__ )
-  
-  boot host_namespace: EchoServer,
-       app_id: 'echo-server-with-cli-and-env-config',
-       app_name: 'Echo Server With CLI And Env Config',
-       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
-       author: 'LFE',
-       use_config: true,
-       default_config_path: "#{PROJECT_ROOT}/config/5.conf",
-       default_log_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.log",
-       default_pid_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.pid",
-       default_thread_count: nil
-
-  class Cli < Servitude::Cli::Service
-  end
 
   class Server
 
@@ -104,6 +90,21 @@ module EchoServer
     attr_reader :tcp_server
 
   end
+
+  boot host_namespace: EchoServer,
+       app_id: 'echo-server-with-cli-and-env-config',
+       app_name: 'Echo Server With CLI And Env Config',
+       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
+       author: 'LFE',
+       use_config: true,
+       default_config_path: "#{PROJECT_ROOT}/config/5.conf",
+       default_log_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.log",
+       default_pid_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.pid",
+       default_thread_count: nil
+
+  class Cli < Servitude::Cli::Service
+  end
+
 end
 
 EchoServer::Cli.start

--- a/lib/servitude.rb
+++ b/lib/servitude.rb
@@ -1,5 +1,6 @@
 require 'servitude/version'
 require 'rainbow'
+require 'yell'
 
 module Servitude
 
@@ -22,7 +23,25 @@ module Servitude
   TERM = "TERM"
 
   class << self
-    attr_accessor :boot_called
+    attr_accessor :boot_called, :configuration, :logger
+
+    def initialize_loggers( log_level: nil, filename: nil )
+      raise ArgumentError, 'log_level keyword is required' unless log_level
+
+      logger.adapter.close if logger && logger.adapter
+
+      self.logger = Yell.new do |l|
+        l.level = log_level
+        if filename
+          l.adapter :file, filename, :level => [:debug, :info, :warn]
+        else
+          l.adapter $stdout, :level => [:debug, :info, :warn]
+          l.adapter $stderr, :level => [:error, :fatal]
+        end
+      end
+    end
   end
+
+  Servitude.initialize_loggers log_level: :info
 
 end

--- a/lib/servitude/base.rb
+++ b/lib/servitude/base.rb
@@ -27,6 +27,7 @@ module Servitude
                 default_log_path: nil,
                 default_pid_path: nil,
                 default_thread_count: nil,
+                server_class: ( host_namespace::Server rescue nil ),
                 version_copyright: nil ) # TODO: Remove when version_copyright keyword deprecation expires
         unless host_namespace
           raise ArgumentError, 'host_namespace keyword is required'
@@ -51,6 +52,10 @@ module Servitude
           author = company
         end
 
+        unless server_class
+          raise ArgumentError, "server_class keyword is required because the default, #{host_namespace.name}::Server, is not defined"
+        end
+
         # TODO: Remove when version_copyright keyword deprecation expires
         if version_copyright
           Util.deprecate "#{Base.name}.boot version_copyright: #{version_copyright.inspect}",
@@ -58,8 +63,7 @@ module Servitude
           attribution = version_copyright
         end
 
-        Servitude::const_set :NS, host_namespace
-
+        # TODO: Remove when host namespace deprecation expires
         const_set :APP_ID, app_id
         const_set :APP_NAME, app_name
         const_set :AUTHOR, author
@@ -71,6 +75,19 @@ module Servitude
         const_set :DEFAULT_THREAD_COUNT, default_thread_count
         const_set :USE_CONFIG, use_config
         const_set :VERSION_COPYRIGHT, attribution # TODO: Remove when version_copyright keyword deprecation expires
+
+        Servitude.const_set :APP_ID, app_id
+        Servitude.const_set :APP_NAME, app_name
+        Servitude.const_set :AUTHOR, author
+        Servitude.const_set :COMPANY, author # TODO: Remove when company keyword deprecation expires
+        Servitude.const_set :ATTRIBUTION, attribution
+        Servitude.const_set :DEFAULT_CONFIG_PATH, default_config_path
+        Servitude.const_set :DEFAULT_LOG_PATH, default_log_path
+        Servitude.const_set :DEFAULT_PID_PATH, default_pid_path
+        Servitude.const_set :DEFAULT_THREAD_COUNT, default_thread_count
+        Servitude.const_set :SERVER_CLASS, server_class
+        Servitude.const_set :USE_CONFIG, use_config
+        Servitude.const_set :VERSION_COPYRIGHT, attribution # TODO: Remove when version_copyright keyword deprecation expires
 
         Servitude::boot_called = true
       end

--- a/lib/servitude/cli/service.rb
+++ b/lib/servitude/cli/service.rb
@@ -7,15 +7,15 @@ module Servitude
       end
 
       def self.pid_option
-        method_option :pid, desc: "The path for the PID file", type: :string, default: Servitude::NS::DEFAULT_PID_PATH
+        method_option :pid, desc: "The path for the PID file", type: :string, default: Servitude::DEFAULT_PID_PATH
       end
 
       def self.common_start_options
-        method_option :config, type: :string, aliases: '-c', desc: "The path for the config file", default: Servitude::NS::DEFAULT_CONFIG_PATH
+        method_option :config, type: :string, aliases: '-c', desc: "The path for the config file", default: Servitude::DEFAULT_CONFIG_PATH
         environment_option
         method_option :log_level, desc: "The log level", type: :string, aliases: '-o', default: 'info'
-        method_option :log, desc: "The path for the log file", type: :string, aliases: '-l', default: Servitude::NS::DEFAULT_LOG_PATH
-        method_option :threads, desc: "The number of threads", type: :numeric, aliases: '-t', default: Servitude::NS::DEFAULT_THREAD_COUNT
+        method_option :log, desc: "The path for the log file", type: :string, aliases: '-l', default: Servitude::DEFAULT_LOG_PATH
+        method_option :threads, desc: "The number of threads", type: :numeric, aliases: '-t', default: Servitude::DEFAULT_THREAD_COUNT
       end
 
       desc "restart", "Stop and start the server"
@@ -41,12 +41,12 @@ module Servitude
       no_commands do
 
         def start_interactive
-          server = Servitude::NS::Server.new( options.merge( use_config: Servitude::NS::USE_CONFIG, log: 'STDOUT' ))
+          server = Servitude::SERVER_CLASS.new( options.merge( use_config: Servitude::USE_CONFIG, log: 'STDOUT' ))
           server.start
         end
 
         def start_daemon
-          server = Servitude::Daemon.new( options.merge( use_config: Servitude::NS::USE_CONFIG ))
+          server = Servitude::Daemon.new( options.merge( use_config: Servitude::USE_CONFIG ))
           server.start
         end
 
@@ -55,13 +55,13 @@ module Servitude
       desc "status", "Check the status of the server daemon"
       pid_option
       def status
-        Servitude::Daemon.new( options.merge( use_config: Servitude::NS::USE_CONFIG )).status
+        Servitude::Daemon.new( options.merge( use_config: Servitude::USE_CONFIG )).status
       end
 
       desc "stop", "Stop the server daemon"
       pid_option
       def stop
-        server = Servitude::Daemon.new( options.merge( use_config: Servitude::NS::USE_CONFIG ))
+        server = Servitude::Daemon.new( options.merge( use_config: Servitude::USE_CONFIG ))
         server.stop
       end
 

--- a/lib/servitude/config_helper.rb
+++ b/lib/servitude/config_helper.rb
@@ -2,7 +2,7 @@ module Servitude
   module ConfigHelper
 
     def config
-      Servitude::NS::configuration
+      Servitude.configuration
     end
 
   end

--- a/lib/servitude/daemon.rb
+++ b/lib/servitude/daemon.rb
@@ -14,7 +14,7 @@ module Servitude
 
     def initialize( options )
       @options  = options
-      @name     = options[:name] || Servitude::NS::APP_NAME
+      @name     = options[:name] || Servitude::APP_NAME
       @pid_path = options[:pid] || '.'
       @pid      = get_pid
       @timeout  = options[:timeout] || 10
@@ -37,7 +37,7 @@ module Servitude
     end
 
     def run
-      Servitude::NS::Server.new( options ).start
+      Servitude::SERVER_CLASS.new( options ).start
     end
 
     def stop
@@ -46,7 +46,7 @@ module Servitude
           remove_pid
         when :failed_to_stop
         when :does_not_exist
-          puts "#{Servitude::NS::APP_NAME} process is not running"
+          puts "#{Servitude::APP_NAME} process is not running"
           prompt_and_remove_pid_file if pid_file_exists?
         else
           raise 'Unknown return code from #kill_process'
@@ -55,9 +55,9 @@ module Servitude
 
     def status
       if process_exists?
-        puts "#{Servitude::NS::APP_NAME} process running with PID: #{pid}"
+        puts "#{Servitude::APP_NAME} process running with PID: #{pid}"
       else
-        puts "#{Servitude::NS::APP_NAME} process does not exist"
+        puts "#{Servitude::APP_NAME} process does not exist"
         prompt_and_remove_pid_file if pid_file_exists?
       end
     end
@@ -110,7 +110,7 @@ module Servitude
     def kill_process
       return :does_not_exist unless process_exists?
 
-      $stdout.write "Attempting to stop #{Servitude::NS::APP_NAME} process #{pid}..."
+      $stdout.write "Attempting to stop #{Servitude::APP_NAME} process #{pid}..."
       Process.kill INT, pid
 
       iteration_num = 0
@@ -121,10 +121,10 @@ module Servitude
       end
 
       if process_exists?
-        $stderr.puts "\nFailed to stop #{Servitude::NS::APP_NAME} process #{pid}"
+        $stderr.puts "\nFailed to stop #{Servitude::APP_NAME} process #{pid}"
         return :failed_to_stop
       else
-        $stdout.puts "\nSuccessfuly stopped #{Servitude::NS::APP_NAME} process #{pid}"
+        $stdout.puts "\nSuccessfuly stopped #{Servitude::APP_NAME} process #{pid}"
       end
 
       return :success

--- a/lib/servitude/logging.rb
+++ b/lib/servitude/logging.rb
@@ -11,7 +11,7 @@ module Servitude
 
       define_method level do |*messages|
         messages.each do |message|
-          Servitude::NS.logger.send level, message
+          Servitude.logger.send level, message
         end
       end
 

--- a/lib/servitude/server.rb
+++ b/lib/servitude/server.rb
@@ -53,7 +53,7 @@ module Servitude
     end
 
     def initialize_config
-      Servitude::NS::configuration = configuration_class.new( cli_options )
+      Servitude.configuration = configuration_class.new( cli_options )
     end
 
     def configuration_class

--- a/lib/servitude/server_logging.rb
+++ b/lib/servitude/server_logging.rb
@@ -1,5 +1,3 @@
-require 'yell'
-
 # Provides logging services for the base server.
 #
 module Servitude
@@ -8,16 +6,12 @@ module Servitude
   protected
 
     def initialize_loggers
-      Servitude::NS.logger = Yell.new do |l|
-        l.level = log_level
-        l.adapter $stdout, :level => [:debug, :info, :warn]
-        l.adapter $stderr, :level => [:error, :fatal]
-      end
+      Servitude.initialize_loggers log_level: log_level
     end
 
     def log_startup
       start_banner.each do |line|
-        Servitude::NS.logger.info line
+        Servitude.logger.info line
       end
     end
 
@@ -25,19 +19,19 @@ module Servitude
       [
         "",
         "***",
-        "* #{Servitude::NS::APP_NAME} started",
+        "* #{Servitude::APP_NAME} started",
         "*",
-        "* #{Servitude::NS::VERSION_COPYRIGHT}",
+        "* #{Servitude::VERSION_COPYRIGHT}",
         "*",
-        (Servitude::NS::configuration.empty? ? nil : "* Configuration"),
-        PrettyPrint::configuration_lines( Servitude::NS::configuration, "*  ", all_config_filters ),
-        (Servitude::NS::configuration.empty? ? nil : "*"),
+        (Servitude.configuration.empty? ? nil : "* Configuration"),
+        PrettyPrint::configuration_lines( Servitude.configuration, "*  ", all_config_filters ),
+        (Servitude.configuration.empty? ? nil : "*"),
         "***",
       ].flatten.reject( &:nil? )
     end
 
     def log_level
-      ((Servitude::NS::configuration.log_level || :info).to_sym rescue :info)
+      (Servitude.configuration.log_level.to_sym rescue :info)
     end
 
     def all_config_filters
@@ -59,7 +53,7 @@ module Servitude
     end
 
     #def config_value( key )
-      #value = Servitude::NS.configuration.send( key )
+      #value = Servitude.configuration.send( key )
 
       #return value unless value.is_a?( Hash )
 

--- a/lib/servitude/util.rb
+++ b/lib/servitude/util.rb
@@ -4,13 +4,15 @@ module Servitude
 
   module Util
 
-    def self.deprecate( deprecated_usage, sanctioned_usage )
+    def self.deprecate( deprecated_usage, sanctioned_usage=nil )
       $stderr.print Rainbow( " *** DEPRECATED " ).yellow.inverse
       $stderr.print ' '
       $stderr.print Rainbow( deprecated_usage ).underline
-      $stderr.print Rainbow(" -- use ")
-      $stderr.print Rainbow( sanctioned_usage ).underline
-      $stderr.print Rainbow(" instead")
+      if sanctioned_usage
+        $stderr.print Rainbow(" -- use ")
+        $stderr.print Rainbow( sanctioned_usage ).underline
+        $stderr.print Rainbow(" instead")
+      end
       $stderr.puts ''
     end
 


### PR DESCRIPTION
This puts all the constants ([_APP_ID_](https://github.com/midas/servitude/blob/b114fff5a70293482940f4c2e427d49254376a00/lib/servitude/base.rb#L63), etc) and [configuration](https://github.com/midas/servitude/blob/b114fff5a70293482940f4c2e427d49254376a00/lib/servitude/base.rb#L78-88) and [logging](https://github.com/midas/servitude/blob/b114fff5a70293482940f4c2e427d49254376a00/lib/servitude/base.rb#L12) APIs into the [_Servitude_](https://github.com/midas/servitude/blob/6438eaa1f8c230a24d3debeba9075d11578edf52/lib/servitude.rb#L4-28) namespace instead of injecting them into the application’s namespace. This simplifies the code and makes it possible to use logging statements while running unit tests (regardless of whether Servitude has been [boot](https://github.com/midas/servitude/blob/b114fff5a70293482940f4c2e427d49254376a00/lib/servitude/base.rb#L19-90)ed or a Servitude server is running).

We introduce a new `server_class` optional keyword to _Servitude.boot_. Its value is a [_Class_](http://ruby-doc.org/core-2.1.0/Class.html) object, and it must be supplied if a _Server_ class in the host namespace is not defined.

The changes to examples entail booting after the _Server_ class is defined rather than before, for reasons just mentioned.
