### PR TITLE
Lazy evaluation of ‘Server’ class

### DIFF
--- a/examples/1_simple_server
+++ b/examples/1_simple_server
@@ -21,6 +21,17 @@ module SimpleServer
   VERSION    = '1.0.0'
 
   PROJECT_ROOT = File.expand_path( '../..', __FILE__ )
+  
+  boot host_namespace: SimpleServer,
+       app_id: 'simple-server',
+       app_name: 'Simple Server',
+       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
+       author: 'LFE',
+       use_config: false,
+       default_config_path: nil,
+       default_log_path: nil,
+       default_pid_path: nil,
+       default_thread_count: nil
 
   class Server
 
@@ -35,17 +46,6 @@ module SimpleServer
     end
 
   end
-
-  boot host_namespace: SimpleServer,
-       app_id: 'simple-server',
-       app_name: 'Simple Server',
-       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
-       author: 'LFE',
-       use_config: false,
-       default_config_path: nil,
-       default_log_path: nil,
-       default_pid_path: nil,
-       default_thread_count: nil
 end
 
 SimpleServer::Server.new.start

--- a/examples/2_echo_server
+++ b/examples/2_echo_server
@@ -27,6 +27,17 @@ module EchoServer
   VERSION    = '1.0.0'
 
   PROJECT_ROOT = File.expand_path( '../..', __FILE__ )
+  
+  boot host_namespace: EchoServer,
+       app_id: 'echo-server',
+       app_name: 'Echo Server',
+       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
+       author: 'LFE',
+       use_config: false,
+       default_config_path: nil,
+       default_log_path: nil,
+       default_pid_path: nil,
+       default_thread_count: nil
 
   class Server
 
@@ -57,17 +68,6 @@ module EchoServer
     attr_reader :tcp_server
 
   end
-
-  boot host_namespace: EchoServer,
-       app_id: 'echo-server',
-       app_name: 'Echo Server',
-       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
-       author: 'LFE',
-       use_config: false,
-       default_config_path: nil,
-       default_log_path: nil,
-       default_pid_path: nil,
-       default_thread_count: nil
 end
 
 EchoServer::Server.new.start

--- a/examples/3_echo_server_with_cli_and_daemon
+++ b/examples/3_echo_server_with_cli_and_daemon
@@ -38,6 +38,20 @@ module EchoServer
   VERSION    = '1.0.0'
 
   PROJECT_ROOT = File.expand_path( '../..', __FILE__ )
+  
+  boot host_namespace: EchoServer,
+       app_id: 'echo-server-with-cli',
+       app_name: 'Echo Server With CLI',
+       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
+       author: 'LFE',
+       use_config: false,
+       default_config_path: "#{PROJECT_ROOT}}/config/#{APP_FOLDER}.conf",
+       default_log_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.log",
+       default_pid_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.pid",
+       default_thread_count: nil
+
+  class Cli < Servitude::Cli::Service
+  end
 
   class Server
 
@@ -74,21 +88,6 @@ module EchoServer
     attr_reader :tcp_server
 
   end
-
-  boot host_namespace: EchoServer,
-       app_id: 'echo-server-with-cli',
-       app_name: 'Echo Server With CLI',
-       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
-       author: 'LFE',
-       use_config: false,
-       default_config_path: "#{PROJECT_ROOT}}/config/#{APP_FOLDER}.conf",
-       default_log_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.log",
-       default_pid_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.pid",
-       default_thread_count: nil
-
-  class Cli < Servitude::Cli::Service
-  end
-
 end
 
 EchoServer::Cli.start

--- a/examples/4_echo_server_with_cli_daemon_and_file_config
+++ b/examples/4_echo_server_with_cli_daemon_and_file_config
@@ -38,6 +38,20 @@ module EchoServer
   VERSION    = '1.0.0'
 
   PROJECT_ROOT = File.expand_path( '../..', __FILE__ )
+  
+  boot host_namespace: EchoServer,
+       app_id: 'echo-server-with-cli-and-file-config',
+       app_name: 'Echo Server With CLI And File Config',
+       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
+       author: 'LFE',
+       use_config: true,
+       default_config_path: "#{PROJECT_ROOT}/config/4.conf",
+       default_log_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.log",
+       default_pid_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.pid",
+       default_thread_count: nil
+
+  class Cli < Servitude::Cli::Service
+  end
 
   class Server
 
@@ -74,21 +88,6 @@ module EchoServer
     attr_reader :tcp_server
 
   end
-
-  boot host_namespace: EchoServer,
-       app_id: 'echo-server-with-cli-and-file-config',
-       app_name: 'Echo Server With CLI And File Config',
-       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
-       author: 'LFE',
-       use_config: true,
-       default_config_path: "#{PROJECT_ROOT}/config/4.conf",
-       default_log_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.log",
-       default_pid_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.pid",
-       default_thread_count: nil
-
-  class Cli < Servitude::Cli::Service
-  end
-
 end
 
 EchoServer::Cli.start

--- a/examples/5_echo_server_with_cli_daemon_and_env_config
+++ b/examples/5_echo_server_with_cli_daemon_and_env_config
@@ -46,6 +46,20 @@ module EchoServer
   VERSION    = '1.0.0'
 
   PROJECT_ROOT = File.expand_path( '../..', __FILE__ )
+  
+  boot host_namespace: EchoServer,
+       app_id: 'echo-server-with-cli-and-env-config',
+       app_name: 'Echo Server With CLI And Env Config',
+       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
+       author: 'LFE',
+       use_config: true,
+       default_config_path: "#{PROJECT_ROOT}/config/5.conf",
+       default_log_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.log",
+       default_pid_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.pid",
+       default_thread_count: nil
+
+  class Cli < Servitude::Cli::Service
+  end
 
   class Server
 
@@ -90,21 +104,6 @@ module EchoServer
     attr_reader :tcp_server
 
   end
-
-  boot host_namespace: EchoServer,
-       app_id: 'echo-server-with-cli-and-env-config',
-       app_name: 'Echo Server With CLI And Env Config',
-       attribution: "v#{VERSION} \u00A9#{Time.now.year} LFE",
-       author: 'LFE',
-       use_config: true,
-       default_config_path: "#{PROJECT_ROOT}/config/5.conf",
-       default_log_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.log",
-       default_pid_path: "#{PROJECT_ROOT}/tmp/#{APP_FOLDER}.pid",
-       default_thread_count: nil
-
-  class Cli < Servitude::Cli::Service
-  end
-
 end
 
 EchoServer::Cli.start

--- a/lib/servitude.rb
+++ b/lib/servitude.rb
@@ -40,6 +40,15 @@ module Servitude
         end
       end
     end
+
+    def server_class
+      case SERVER_CLASS
+        when String, Symbol
+          eval SERVER_CLASS.to_s, binding, __FILE__, __LINE__
+        else
+          SERVER_CLASS
+      end
+    end
   end
 
   Servitude.initialize_loggers log_level: :info

--- a/lib/servitude/base.rb
+++ b/lib/servitude/base.rb
@@ -27,7 +27,7 @@ module Servitude
                 default_log_path: nil,
                 default_pid_path: nil,
                 default_thread_count: nil,
-                server_class: ( host_namespace::Server rescue nil ),
+                server_class: ( host_namespace::Server rescue "#{host_namespace.name}::Server" ),
                 version_copyright: nil ) # TODO: Remove when version_copyright keyword deprecation expires
         unless host_namespace
           raise ArgumentError, 'host_namespace keyword is required'
@@ -53,7 +53,7 @@ module Servitude
         end
 
         unless server_class
-          raise ArgumentError, "server_class keyword is required because the default, #{host_namespace.name}::Server, is not defined"
+          raise ArgumentError, 'server_class keyword is required'
         end
 
         # TODO: Remove when version_copyright keyword deprecation expires

--- a/lib/servitude/cli/service.rb
+++ b/lib/servitude/cli/service.rb
@@ -41,7 +41,7 @@ module Servitude
       no_commands do
 
         def start_interactive
-          server = Servitude::SERVER_CLASS.new( options.merge( use_config: Servitude::USE_CONFIG, log: 'STDOUT' ))
+          server = Servitude::server_class.new( options.merge( use_config: Servitude::USE_CONFIG, log: 'STDOUT' ))
           server.start
         end
 

--- a/lib/servitude/daemon.rb
+++ b/lib/servitude/daemon.rb
@@ -37,7 +37,7 @@ module Servitude
     end
 
     def run
-      Servitude::SERVER_CLASS.new( options ).start
+      Servitude::server_class.new( options ).start
     end
 
     def stop


### PR DESCRIPTION
Don’t require the host’s _Server_ class to be defined at boot time.
