### PR TITLE
Avoid mistaking pid and configuration directories for files

### DIFF
--- a/lib/servitude/configuration.rb
+++ b/lib/servitude/configuration.rb
@@ -23,7 +23,7 @@ module Servitude
     attr_reader :_config
 
     def file_options( file_path )
-      unless File.exists?( file_path )
+      unless File.file?( file_path )
         raise "Configuration file #{file_path} does not exist"
       end
 

--- a/lib/servitude/daemon.rb
+++ b/lib/servitude/daemon.rb
@@ -74,7 +74,7 @@ module Servitude
     end
 
     def remove_pid
-      FileUtils.rm( pid_path ) if File.exists?( pid_path )
+      FileUtils.rm( pid_path ) if File.file?( pid_path )
     end
 
     def store_pid( pid )
@@ -87,7 +87,7 @@ module Servitude
     end
 
     def get_pid
-      return nil unless File.exists?( pid_path )
+      return nil unless File.file?( pid_path )
 
       pid = nil
 
@@ -133,7 +133,7 @@ module Servitude
     end
 
     def pid_file_exists?
-      File.exists?( pid_path )
+      File.file? pid_path
     end
 
     def process_exists?


### PR DESCRIPTION
Using [_File.exist?_](http://ruby-doc.org/core-2.1.0/File.html#method-c-exist-3F) instead of [_File.file?_](http://ruby-doc.org/core-2.1.0/File.html#method-c-file-3F) gives a false-positive result when the path argument is a directory (such as _._) instead of a file. This happens if the pid file path is its default value (_._).
