### PR TITLE
Set the process exit status after finishing the 'status' subcommand

### DIFF
--- a/lib/servitude/cli/service.rb
+++ b/lib/servitude/cli/service.rb
@@ -55,7 +55,8 @@ module Servitude
       desc "status", "Check the status of the server daemon"
       pid_option
       def status
-        Servitude::Daemon.new( options.merge( use_config: Servitude::USE_CONFIG )).status
+        result = Servitude::Daemon.new( options.merge( use_config: Servitude::USE_CONFIG )).status
+        at_exit { exit result }
       end
 
       desc "stop", "Stop the server daemon"

--- a/lib/servitude/daemon.rb
+++ b/lib/servitude/daemon.rb
@@ -56,9 +56,11 @@ module Servitude
     def status
       if process_exists?
         puts "#{Servitude::APP_NAME} process running with PID: #{pid}"
+        true
       else
         puts "#{Servitude::APP_NAME} process does not exist"
         prompt_and_remove_pid_file if pid_file_exists?
+        false
       end
     end
 


### PR DESCRIPTION
This is necessary in order for other scripts to know that the status was nominal or troubled, since there is console output in either case.
