### PR TITLE
Introduce '--quiet'/-q' option to the 'status' subcommand

### DIFF
--- a/lib/servitude/cli/service.rb
+++ b/lib/servitude/cli/service.rb
@@ -54,6 +54,7 @@ module Servitude
 
       desc "status", "Check the status of the server daemon"
       pid_option
+      method_option :quiet, type: :boolean, aliases: '-q', desc: "Do not prompt to remove an old PID file", default: false
       def status
         result = Servitude::Daemon.new( options.merge( use_config: Servitude::USE_CONFIG )).status
         at_exit { exit result }

--- a/lib/servitude/daemon.rb
+++ b/lib/servitude/daemon.rb
@@ -59,7 +59,7 @@ module Servitude
         true
       else
         puts "#{Servitude::APP_NAME} process does not exist"
-        prompt_and_remove_pid_file if pid_file_exists?
+        prompt_and_remove_pid_file if pid_file_exists? && !options[:quiet]
         false
       end
     end


### PR DESCRIPTION
This option will bypass the prompt (and the routine) to remove an old PID file.

Fixes #10.
