### PR TITLE
Introduce '--quiet'/-q' option to the 'stop' subcommand

### DIFF
--- a/lib/servitude/cli/service.rb
+++ b/lib/servitude/cli/service.rb
@@ -62,6 +62,7 @@ module Servitude
 
       desc "stop", "Stop the server daemon"
       pid_option
+      method_option :quiet, type: :boolean, aliases: '-q', desc: "Do not prompt to remove an old PID file", default: false
       def stop
         server = Servitude::Daemon.new( options.merge( use_config: Servitude::USE_CONFIG ))
         server.stop

--- a/lib/servitude/daemon.rb
+++ b/lib/servitude/daemon.rb
@@ -47,7 +47,7 @@ module Servitude
         when :failed_to_stop
         when :does_not_exist
           puts "#{Servitude::APP_NAME} process is not running"
-          prompt_and_remove_pid_file if pid_file_exists?
+          prompt_and_remove_pid_file if pid_file_exists? && !options[:quiet]
         else
           raise 'Unknown return code from #kill_process'
       end


### PR DESCRIPTION
This option will bypass the prompt (and the routine) to remove an old PID file.

Fixes #15.
